### PR TITLE
Fix member logo scaling in members cards

### DIFF
--- a/website/layouts/members/summary.html
+++ b/website/layouts/members/summary.html
@@ -1,0 +1,17 @@
+<div class="member-summary">
+  {{ if .Params.image }}
+  <a class="member-summary-logo" href="{{ .RelPermalink }}" aria-label="View {{ .Title }} member details">
+    <img alt="{{ .Title }} logo" src="{{ .Params.image | relURL }}" />
+  </a>
+  {{ end }}
+
+  <div class="member-summary-content">
+    <h2 class="member-summary-title">
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    </h2>
+    {{ with .Params.jobtitle }}
+    <p class="member-summary-type">{{ . }}</p>
+    {{ end }}
+    <p class="member-summary-description">{{ .Summary | plainify | htmlUnescape }}</p>
+  </div>
+</div>

--- a/website/themes/hugo-serif-theme/assets/scss/pages/members/_member-summary.scss
+++ b/website/themes/hugo-serif-theme/assets/scss/pages/members/_member-summary.scss
@@ -1,0 +1,56 @@
+.member-summary {
+  height: 100%;
+  padding: 24px;
+  background-color: $white-offset;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+
+  .member-summary-logo {
+    width: 100%;
+    height: 110px;
+    border-radius: 4px;
+    background-color: $white;
+    border: 1px solid rgba($black, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px;
+    margin-bottom: 16px;
+
+    img {
+      display: block;
+      max-width: 100%;
+      max-height: 100%;
+      width: auto;
+      height: auto;
+      object-fit: contain;
+    }
+  }
+
+  .member-summary-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .member-summary-title {
+    margin: 0 0 8px;
+    font-size: 24px;
+  }
+
+  .member-summary-type {
+    margin: 0 0 12px;
+    color: $black;
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 0.4px;
+    font-weight: 600;
+  }
+
+  .member-summary-description {
+    margin: 0;
+    color: $grey;
+    line-height: 1.5;
+  }
+}

--- a/website/themes/hugo-serif-theme/assets/scss/style.scss
+++ b/website/themes/hugo-serif-theme/assets/scss/style.scss
@@ -46,6 +46,7 @@ $font-family-heading: {{ .Site.Params.fonts.heading }}, serif, -apple-system;
 // Pages
 @import 'pages/home';
 @import 'pages/team/team-summary';
+@import 'pages/members/member-summary';
 @import 'pages/services/page-services-single';
 
 body {


### PR DESCRIPTION
### Motivation
- Member logos were rendering at their intrinsic sizes and overflowing or appearing inconsistent inside member cards, so a structured logo container and explicit scaling rules are needed to ensure a uniform card layout.

### Description
- Add a dedicated members summary template at `website/layouts/members/summary.html` to render a logo box, title, job title, and description for each member.
- Add `website/themes/hugo-serif-theme/assets/scss/pages/members/_member-summary.scss` which provides a fixed-height logo container and sets `object-fit: contain` on logos so they scale to fit without cropping.
- Import the new members stylesheet into the theme entrypoint by updating `website/themes/hugo-serif-theme/assets/scss/style.scss` to `@import 'pages/members/member-summary';`.

### Testing
- Ran `git diff --check` which reported no index/whitespace issues and completed successfully.
- Attempted `cd website && hugo` to build the site but the `hugo` binary is not available in this environment so the site render could not be validated locally.
- Attempted to install `hugo` with `apt-get install -y hugo` but the environment's apt repositories returned `403 Forbidden`, so installation failed.
- Attempted a Playwright screenshot of `http://127.0.0.1:1313/members/` which failed with `ERR_EMPTY_RESPONSE` because no local Hugo server was running due to the missing `hugo` binary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b66a8c857883249cb00b3d3dc6333a)