### PR TITLE
Improve initiatives page layout with member-style summary cards

### DIFF
--- a/website/layouts/initiatives/list.html
+++ b/website/layouts/initiatives/list.html
@@ -1,0 +1,22 @@
+{{ define "body_classes" }}page-initiatives-list{{ end }}
+
+{{ define "main" }}
+<div class="intro">
+  <div class="container">
+    <div class="row justify-content-start">
+      <div class="col-12 col-md-7 col-lg-6 order-2 order-md-1">
+        {{ .Content }}
+      </div>
+      {{ partial "intro-image.html" . }}
+    </div>
+  </div>
+</div>
+
+<div class="container pt-6 pb-6">
+  <div class="row">
+    {{ range .Pages.ByWeight }}
+    <div class="col-12 col-md-6 mb-3">{{ .Render "summary" }}</div>
+    {{ end }}
+  </div>
+</div>
+{{ end }}

--- a/website/layouts/initiatives/summary.html
+++ b/website/layouts/initiatives/summary.html
@@ -1,0 +1,11 @@
+<div class="initiative-summary">
+  <div class="initiative-summary-content">
+    <h2 class="initiative-summary-title">
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    </h2>
+    <p class="initiative-summary-description">{{ .Summary | plainify | htmlUnescape | truncate 180 "…" }}</p>
+  </div>
+  <div class="initiative-summary-footer">
+    <a class="initiative-summary-link" href="{{ .RelPermalink }}">Learn more</a>
+  </div>
+</div>

--- a/website/themes/hugo-serif-theme/assets/scss/pages/initiatives/_initiative-summary.scss
+++ b/website/themes/hugo-serif-theme/assets/scss/pages/initiatives/_initiative-summary.scss
@@ -1,0 +1,40 @@
+.initiative-summary {
+  height: 100%;
+  padding: 24px;
+  background-color: $white-offset;
+  border-radius: 4px;
+  border: 1px solid rgba($black, 0.08);
+  display: flex;
+  flex-direction: column;
+
+  .initiative-summary-content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
+  .initiative-summary-title {
+    margin: 0 0 12px;
+    font-size: 24px;
+    line-height: 1.2;
+  }
+
+  .initiative-summary-description {
+    margin: 0;
+    color: $grey;
+    line-height: 1.55;
+  }
+
+  .initiative-summary-footer {
+    margin-top: 16px;
+  }
+
+  .initiative-summary-link {
+    font-weight: 600;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/website/themes/hugo-serif-theme/assets/scss/style.scss
+++ b/website/themes/hugo-serif-theme/assets/scss/style.scss
@@ -47,6 +47,7 @@ $font-family-heading: {{ .Site.Params.fonts.heading }}, serif, -apple-system;
 @import 'pages/home';
 @import 'pages/team/team-summary';
 @import 'pages/members/member-summary';
+@import 'pages/initiatives/initiative-summary';
 @import 'pages/services/page-services-single';
 
 body {


### PR DESCRIPTION
### Motivation
- Make the `/initiatives/` section visually consistent with the members page by using an intro + two-column card grid and clearer card summaries.
- Improve readability and hierarchy for initiative entries by surfacing title, a trimmed description, and a clear call-to-action.

### Description
- Add a dedicated list template at `website/layouts/initiatives/list.html` that uses the same intro + two-column grid pattern as other list pages.
- Add a custom summary template at `website/layouts/initiatives/summary.html` that renders each initiative as a card with linked title, truncated description, and a “Learn more” link.
- Add SCSS styling at `website/themes/hugo-serif-theme/assets/scss/pages/initiatives/_initiative-summary.scss` to provide card visuals, spacing, borders, and link styling.
- Wire the new stylesheet into the main theme imports by adding `@import 'pages/initiatives/initiative-summary';` to `website/themes/hugo-serif-theme/assets/scss/style.scss`.

### Testing
- Attempted to build the site with `cd website && hugo`, which failed because the `hugo` binary is not available in this environment.
- Attempted to install `hugo` via `apt-get`, which failed due to repository/network proxy `403` responses in the environment.
- Attempted to download the Hugo tarball with `curl` and run it locally, which also failed due to outbound network/proxy restrictions returning `403`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b66c7626348324963e53d3e9a84bdf)