### PR TITLE
Improve Services page with initiative-style service cards

### DIFF
--- a/website/content/services/_index.md
+++ b/website/content/services/_index.md
@@ -1,15 +1,10 @@
 ---
 title: 'Services'
+description: 'Infrastructure and collaboration services operated by ossbase.org.'
 intro_image: "images/illustrations/services.jpg"
 intro_image_absolute: false 
 intro_image_absolute_offset: "auto auto -148px -102px"
 intro_image_hide_on_mobile: false
 ---
 
-# Services operated by ossbase.org
-
-## [discourse.ossbase.org](https://discourse.ossbase.org) 
-
-[Discussion platform](https://discourse.ossbase.org) for the ossbase.org members and their projects.
-
-
+ossbase.org operates practical services that support collaboration across members and open initiatives.

--- a/website/content/services/discourse.md
+++ b/website/content/services/discourse.md
@@ -1,0 +1,14 @@
+---
+title: "discourse.ossbase.org"
+date: 2026-01-01T00:00:00Z
+weight: 1
+summary: "A hosted discussion platform for ossbase.org members and project communities to coordinate work, share updates, and ask questions in the open."
+---
+
+[discourse.ossbase.org](https://discourse.ossbase.org) is the shared discussion platform for ossbase.org members and their projects.
+
+Use it to:
+
+- coordinate project work across organizations,
+- post announcements and release updates,
+- ask technical and governance questions in public.

--- a/website/themes/hugo-serif-theme/assets/scss/pages/services/_service-summary.scss
+++ b/website/themes/hugo-serif-theme/assets/scss/pages/services/_service-summary.scss
@@ -1,0 +1,29 @@
+.page-services-list {
+  .service-summary {
+    height: 100%;
+    padding: 24px;
+    background-color: $white-offset;
+    border-radius: 4px;
+    border: 1px solid rgba($black, 0.08);
+    display: flex;
+    flex-direction: column;
+
+    .service-content {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+    }
+
+    .service-title {
+      margin: 0 0 12px;
+      font-size: 24px;
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0;
+      color: $grey;
+      line-height: 1.55;
+    }
+  }
+}

--- a/website/themes/hugo-serif-theme/assets/scss/style.scss
+++ b/website/themes/hugo-serif-theme/assets/scss/style.scss
@@ -48,6 +48,7 @@ $font-family-heading: {{ .Site.Params.fonts.heading }}, serif, -apple-system;
 @import 'pages/team/team-summary';
 @import 'pages/members/member-summary';
 @import 'pages/initiatives/initiative-summary';
+@import 'pages/services/service-summary';
 @import 'pages/services/page-services-single';
 
 body {

--- a/website/themes/hugo-serif-theme/layouts/services/list.html
+++ b/website/themes/hugo-serif-theme/layouts/services/list.html
@@ -12,10 +12,10 @@
   </div>
 </div>
 
-<div class="container pt-6 pb-6">
+<div class="container pt-6 pb-md-12">
   <div class="row">
     {{ range .Pages.ByWeight }}
-    <div class="col-12 col-md-6 mb-3">{{ .Render "summary" }}</div>
+    <div class="col-12 col-md-6 mb-2">{{ .Render "summary" }}</div>
     {{ end }}
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- Align the Services index with the Initiatives layout so services become first-class list items instead of inline content. 
- Provide a maintainable content pattern where individual services are separate pages that render as cards. 
- Reuse the visual card treatment used for initiatives to give Services a consistent site rhythm and appearance. 

### Description
- Replace the Services index body with a short intro by updating `website/content/services/_index.md` to act like the Initiatives index. 
- Add a dedicated service entry `website/content/services/discourse.md` so the Discourse service renders as a list item/card. 
- Introduce styles for service cards in `website/themes/hugo-serif-theme/assets/scss/pages/services/_service-summary.scss` and import them via `website/themes/hugo-serif-theme/assets/scss/style.scss`. 
- Tweak the services list layout spacing in `website/themes/hugo-serif-theme/layouts/services/list.html` to match the initiatives card rhythm. 

### Testing
- Ran `hugo --source website` as an automated build check and it failed in this environment because `hugo` is not installed. 
- Attempted an automated Playwright screenshot of `http://127.0.0.1:1313/services/` to validate rendering, but it failed because no local server was available to serve the site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b66dc9faa88324854b7339263e122c)